### PR TITLE
add deploy

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,10 +5,6 @@ on:
     tags:
       - 'v*'
 
-env:
-  REGISTRY: registry.darmstadt-1.cloud.gcore.dev/59508-197526-120-infra
-  PROJECT_NAME: ${{ github.event.repository.name }}  # This will automatically use your repository name
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +22,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.DOCKER_REGISTRY }}
+          registry: ${{ vars.DOCKER_REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
@@ -36,4 +32,35 @@ jobs:
           context: "./"
           file: Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.PROJECT_NAME }}:${{ github.ref_name }}
+          tags: ${{ vars.DOCKER_REGISTRY }}/59508-197526-76-infra/tschawytscha-ai-front:${{ github.ref_name }}
+
+  helm-chart:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      CHART_VERSION: ${{ github.ref_name }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Login to Harbor OCI registry
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | helm registry login ${{ vars.DOCKER_REGISTRY }} \
+            --username ${{ secrets.DOCKER_USERNAME }} \
+            --password-stdin
+
+      - name: Package Helm chart
+        run: |
+          helm dependency update install/kubernetes/chart
+          helm package install/kubernetes/chart \
+            --version "${CHART_VERSION#v}" \
+            --app-version "${CHART_VERSION}"
+
+      - name: Push Helm chart to OCI registry
+        run: helm push tschawytscha-ai-front-${CHART_VERSION#v}.tgz oci://${{ vars.DOCKER_REGISTRY }}/59508-197526-76-infra/charts

--- a/install/kubernetes/chart/Chart.yaml
+++ b/install/kubernetes/chart/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: tshawytscha-ai-front
+description: Frontend for tshawytscha.ai AI platform
+type: application
+version: 0.1.0
+appVersion: "0.0.14"
+keywords:
+  - ai
+  - frontend
+  - web
+maintainers:
+  - name: Alex

--- a/install/kubernetes/chart/templates/_helpers.tpl
+++ b/install/kubernetes/chart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "tshawytscha.name" -}}
+{{- .Values.name | default .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tshawytscha.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "tshawytscha.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app: {{ .Values.name }}
+{{- end }}
+
+{{- define "tshawytscha.selectorLabels" -}}
+app: {{ .Values.name }}
+{{- end }}

--- a/install/kubernetes/chart/templates/deployment.yaml
+++ b/install/kubernetes/chart/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    {{- include "tshawytscha.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      {{- include "tshawytscha.selectorLabels" . | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "tshawytscha.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Values.name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/install/kubernetes/chart/templates/httproute.yaml
+++ b/install/kubernetes/chart/templates/httproute.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    {{- include "tshawytscha.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+    {{- end }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  rules:
+    # Route /api/* to backend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: {{ .Values.httpRoute.backendService.name }}
+          port: {{ .Values.httpRoute.backendService.port }}
+    # Route everything else to frontend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.name }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/install/kubernetes/chart/templates/service.yaml
+++ b/install/kubernetes/chart/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    {{- include "tshawytscha.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+  selector:
+    {{- include "tshawytscha.selectorLabels" . | nindent 4 }}

--- a/install/kubernetes/chart/values.yaml
+++ b/install/kubernetes/chart/values.yaml
@@ -1,0 +1,46 @@
+# Frontend values for tshawytscha-ai
+
+name: tshawytscha-ai-front
+
+replicaCount: 1
+
+image:
+  repository: registry.luxembourg-2.cloud.gcore.dev/59508-197526-76-infra/tschawytscha-ai-front
+  tag: "v0.0.14-dev7"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets:
+  - name: registry-secret
+
+# Service configuration
+service:
+  port: 80
+  targetPort: 3000
+
+# HTTPRoute configuration
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - tshawytscha.ai
+  # Backend service to also include in routing (for /api path)
+  backendService:
+    name: tshawytscha-ai-back
+    port: 80
+
+# TLS certificate (cert-manager)
+tls:
+  enabled: true
+  secretName: tshawytscha-ai-tls
+  issuer: letsencrypt-prod
+
+# Resources
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
This pull request introduces Kubernetes Helm chart support for deploying the `tschawytscha-ai-front` application, along with improvements to the Docker build workflow. The main changes include adding new Helm chart files, updating GitHub Actions to package and push the chart, and refining Docker tagging and registry usage.

**Helm chart integration:**

* Added Helm chart files (`Chart.yaml`, `values.yaml`, and templates) to support Kubernetes deployment of the frontend application, including deployment, service, HTTP routing, and helper templates. [[1]](diffhunk://#diff-7efbd6307c7cf58cb7c0c1eb20d9b6e58364cee16481899c07e54dde9a27be68R1-R12) [[2]](diffhunk://#diff-35372752bb01657fde21329e3fa61f2fd33413bcf9ec247600d306abd898494bR1-R46) [[3]](diffhunk://#diff-5c2ea7357e69759f2b09ce23f53deb460953f2c52fc464a4f02d349ed6a57d67R1-R37) [[4]](diffhunk://#diff-fdb239384cb2183e6fb8f011aa257b6f841f6da8b2d48769c333a0304695713fR1-R14) [[5]](diffhunk://#diff-98d1de1e304753669e724a5a83f6b093f0f0c7636667014794ec196057aca1d6R1-R16) [[6]](diffhunk://#diff-4508b10f9a83586a5485510efd2c450225e3f72b9be57e3982eddba2cf03c784R1-R37)

**CI/CD workflow enhancements:**

* Updated `.github/workflows/docker-build.yml` to add a `helm-chart` job that packages and pushes the Helm chart to the OCI registry after building the Docker image.
* Changed Docker registry references in the workflow to use GitHub variables instead of environment variables, improving consistency and maintainability. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L29-R25) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L8-L11)
* Refined Docker image tagging in the workflow to use the new registry path and a fixed project name, aligning with Helm chart deployment.

These changes enable automated container and Helm chart builds and deployments for the frontend application, streamlining the Kubernetes deployment process.